### PR TITLE
Update Discord Nav/Footer Link

### DIFF
--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -23,13 +23,10 @@ function Events() {
       <h3>Upcoming Events</h3>
       <div id="events-placeholder-text">
         The &quot;Events&quot; section is under development.
-        <br />
-        <br />
+        <br /><br />
         In the meantime, please visit
         <br />
-        <a href="https://www.meetup.com/techlifecolumbus/events/">
-          https://www.meetup.com/techlifecolumbus/events/
-        </a>
+        <a href="https://www.meetup.com/techlifecolumbus/events/">https://www.meetup.com/techlifecolumbus/events/</a>
         <br />
         and look for FreeCodeCamp Columbus events there!
       </div>

--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -23,10 +23,13 @@ function Events() {
       <h3>Upcoming Events</h3>
       <div id="events-placeholder-text">
         The &quot;Events&quot; section is under development.
-        <br /><br />
+        <br />
+        <br />
         In the meantime, please visit
         <br />
-        <a href="https://www.meetup.com/techlifecolumbus/events/">https://www.meetup.com/techlifecolumbus/events/</a>
+        <a href="https://www.meetup.com/techlifecolumbus/events/">
+          https://www.meetup.com/techlifecolumbus/events/
+        </a>
         <br />
         and look for FreeCodeCamp Columbus events there!
       </div>

--- a/src/links.js
+++ b/src/links.js
@@ -5,8 +5,5 @@ export default [
   { href: 'https://discord.gg/aF8skEe9nq', text: 'Discord' },
   { href: 'https://github.com/FCCColumbus', text: 'GitHub' },
   { href: '#events', text: 'Events' },
-  {
-    href: 'https://github.com/FCCColumbus/cbus-web/graphs/contributors',
-    text: 'Contributors',
-  },
+  {href: 'https://github.com/FCCColumbus/cbus-web/graphs/contributors',text:'Contributors' },
 ];

--- a/src/links.js
+++ b/src/links.js
@@ -2,8 +2,8 @@ export default [
   { href: '/', text: 'Home' },
   { href: '#about', text: 'About' },
   { href: 'https://www.freecodecamp.org/', text: 'FreeCodeCamp' },
-  { href: 'https://discord.gg/aF8skEe9nq', text: 'Discord' },
+  { href: 'https://discord.com/invite/EXehPVnBYz', text: 'Discord' },
   { href: 'https://github.com/FCCColumbus', text: 'GitHub' },
   { href: '#events', text: 'Events' },
-  {href: 'https://github.com/FCCColumbus/cbus-web/graphs/contributors',text:'Contributors' },
+  { href: 'https://github.com/FCCColumbus/cbus-web/graphs/contributors', text:'Contributors' },
 ];

--- a/src/links.js
+++ b/src/links.js
@@ -2,8 +2,11 @@ export default [
   { href: '/', text: 'Home' },
   { href: '#about', text: 'About' },
   { href: 'https://www.freecodecamp.org/', text: 'FreeCodeCamp' },
-  { href: 'https://discord.gg', text: 'Discord' },
+  { href: 'https://discord.gg/aF8skEe9nq', text: 'Discord' },
   { href: 'https://github.com/FCCColumbus', text: 'GitHub' },
   { href: '#events', text: 'Events' },
-  { href: 'https://github.com/FCCColumbus/cbus-web/graphs/contributors', text: 'Contributors' },
-]
+  {
+    href: 'https://github.com/FCCColumbus/cbus-web/graphs/contributors',
+    text: 'Contributors',
+  },
+];

--- a/src/links.js
+++ b/src/links.js
@@ -5,5 +5,5 @@ export default [
   { href: 'https://discord.com/invite/EXehPVnBYz', text: 'Discord' },
   { href: 'https://github.com/FCCColumbus', text: 'GitHub' },
   { href: '#events', text: 'Events' },
-  { href: 'https://github.com/FCCColumbus/cbus-web/graphs/contributors', text:'Contributors' },
+  { href: 'https://github.com/FCCColumbus/cbus-web/graphs/contributors', text: 'Contributors' },
 ];

--- a/src/test/App.test.js
+++ b/src/test/App.test.js
@@ -12,7 +12,7 @@ describe("App", () => {
   describe("renders links to external sites", () => {
     it.each([
       ['freeCodeCamp.org homepage', 'freecodecamp.org'],
-      ['Discord homepage', 'discord.gg'],
+      ['Discord homepage', 'discord.com/invite/EXehPVnBYz'],
       ['FCCColumbus Github profile', 'github.com/FCCColumbus'],
       ['FCCColumbus Github contributors', 'github.com/FCCColumbus/cbus-web/graphs/contributors'],
     ])(`%s`, (_, expected) => {

--- a/src/test/__snapshots__/App.test.js.snap
+++ b/src/test/__snapshots__/App.test.js.snap
@@ -34,7 +34,7 @@ exports[`App renders 1`] = `
         </li>
         <li>
           <a
-            href="https://discord.gg/aF8skEe9nq"
+            href="https://discord.com/invite/EXehPVnBYz"
           >
             Discord
           </a>
@@ -318,7 +318,7 @@ exports[`App renders 1`] = `
         </li>
         <li>
           <a
-            href="https://discord.gg/aF8skEe9nq"
+            href="https://discord.com/invite/EXehPVnBYz"
           >
             Discord
           </a>

--- a/src/test/__snapshots__/App.test.js.snap
+++ b/src/test/__snapshots__/App.test.js.snap
@@ -34,7 +34,7 @@ exports[`App renders 1`] = `
         </li>
         <li>
           <a
-            href="https://discord.gg"
+            href="https://discord.gg/aF8skEe9nq"
           >
             Discord
           </a>
@@ -318,7 +318,7 @@ exports[`App renders 1`] = `
         </li>
         <li>
           <a
-            href="https://discord.gg"
+            href="https://discord.gg/aF8skEe9nq"
           >
             Discord
           </a>

--- a/src/test/components/Footer.test.js
+++ b/src/test/components/Footer.test.js
@@ -1,10 +1,17 @@
-import renderer from "react-test-renderer";
+import renderer from 'react-test-renderer';
 
-import Footer from "../../components/Footer";
+import Footer from '../../components/Footer';
+import { render, screen } from '@testing-library/react';
 
-describe("Footer", () => {
-  it("renders", () => {
+describe('Footer', () => {
+  it('renders', () => {
     const view = renderer.create(<Footer />);
     expect(view).toMatchSnapshot();
+  });
+
+  it('displays "Discord" as the third item', () => {
+    render(<Footer />);
+    const thirdItem = screen.getByText('Discord');
+    expect(thirdItem).toBeInTheDocument();
   });
 });

--- a/src/test/components/Footer.test.js
+++ b/src/test/components/Footer.test.js
@@ -1,16 +1,10 @@
 import renderer from "react-test-renderer";
+
 import Footer from "../../components/Footer";
-import { render, screen } from "@testing-library/react";
 
 describe("Footer", () => {
   it("renders", () => {
     const view = renderer.create(<Footer />);
     expect(view).toMatchSnapshot();
-  });
-
-  it("displays 'Discord' as the third item", () => {
-    render(<Footer />);
-    const thirdItem = screen.getByText("Discord");
-    expect(thirdItem).toBeInTheDocument();
   });
 });

--- a/src/test/components/Footer.test.js
+++ b/src/test/components/Footer.test.js
@@ -1,17 +1,16 @@
-import renderer from 'react-test-renderer';
+import renderer from "react-test-renderer";
+import Footer from "../../components/Footer";
+import { render, screen } from "@testing-library/react";
 
-import Footer from '../../components/Footer';
-import { render, screen } from '@testing-library/react';
-
-describe('Footer', () => {
-  it('renders', () => {
+describe("Footer", () => {
+  it("renders", () => {
     const view = renderer.create(<Footer />);
     expect(view).toMatchSnapshot();
   });
 
-  it('displays "Discord" as the third item', () => {
+  it("displays 'Discord' as the third item", () => {
     render(<Footer />);
-    const thirdItem = screen.getByText('Discord');
+    const thirdItem = screen.getByText("Discord");
     expect(thirdItem).toBeInTheDocument();
   });
 });

--- a/src/test/components/Header.test.js
+++ b/src/test/components/Header.test.js
@@ -1,10 +1,17 @@
-import renderer from "react-test-renderer";
+import renderer from 'react-test-renderer';
 
-import Header from "../../components/Header";
+import Header from '../../components/Header';
+import { render, screen } from '@testing-library/react';
 
-describe("Header", () => {
-  it("renders", () => {
+describe('Header', () => {
+  it('renders', () => {
     const view = renderer.create(<Header />);
     expect(view).toMatchSnapshot();
+  });
+
+  it('displays "Discord" as the third item', () => {
+    render(<Header />);
+    const thirdItem = screen.getByText('Discord');
+    expect(thirdItem).toBeInTheDocument();
   });
 });

--- a/src/test/components/Header.test.js
+++ b/src/test/components/Header.test.js
@@ -1,17 +1,16 @@
-import renderer from 'react-test-renderer';
+import renderer from "react-test-renderer";
+import Header from "../../components/Header";
+import { render, screen } from "@testing-library/react";
 
-import Header from '../../components/Header';
-import { render, screen } from '@testing-library/react';
-
-describe('Header', () => {
-  it('renders', () => {
+describe("Header", () => {
+  it("renders", () => {
     const view = renderer.create(<Header />);
     expect(view).toMatchSnapshot();
   });
 
-  it('displays "Discord" as the third item', () => {
+  it("displays 'Discord' as the third item", () => {
     render(<Header />);
-    const thirdItem = screen.getByText('Discord');
+    const thirdItem = screen.getByText("Discord");
     expect(thirdItem).toBeInTheDocument();
   });
 });

--- a/src/test/components/Header.test.js
+++ b/src/test/components/Header.test.js
@@ -1,16 +1,10 @@
 import renderer from "react-test-renderer";
+
 import Header from "../../components/Header";
-import { render, screen } from "@testing-library/react";
 
 describe("Header", () => {
   it("renders", () => {
     const view = renderer.create(<Header />);
     expect(view).toMatchSnapshot();
-  });
-
-  it("displays 'Discord' as the third item", () => {
-    render(<Header />);
-    const thirdItem = screen.getByText("Discord");
-    expect(thirdItem).toBeInTheDocument();
   });
 });

--- a/src/test/components/__snapshots__/Footer.test.js.snap
+++ b/src/test/components/__snapshots__/Footer.test.js.snap
@@ -20,7 +20,7 @@ exports[`Footer renders 1`] = `
       </li>
       <li>
         <a
-          href="https://discord.gg"
+          href="https://discord.gg/aF8skEe9nq"
         >
           Discord
         </a>

--- a/src/test/components/__snapshots__/Footer.test.js.snap
+++ b/src/test/components/__snapshots__/Footer.test.js.snap
@@ -20,7 +20,7 @@ exports[`Footer renders 1`] = `
       </li>
       <li>
         <a
-          href="https://discord.gg/aF8skEe9nq"
+          href="https://discord.com/invite/EXehPVnBYz"
         >
           Discord
         </a>

--- a/src/test/components/__snapshots__/Header.test.js.snap
+++ b/src/test/components/__snapshots__/Header.test.js.snap
@@ -31,7 +31,7 @@ exports[`Header renders 1`] = `
       </li>
       <li>
         <a
-          href="https://discord.gg"
+          href="https://discord.gg/aF8skEe9nq"
         >
           Discord
         </a>

--- a/src/test/components/__snapshots__/Header.test.js.snap
+++ b/src/test/components/__snapshots__/Header.test.js.snap
@@ -31,7 +31,7 @@ exports[`Header renders 1`] = `
       </li>
       <li>
         <a
-          href="https://discord.gg/aF8skEe9nq"
+          href="https://discord.com/invite/EXehPVnBYz"
         >
           Discord
         </a>


### PR DESCRIPTION
# TL/DR
This PR updates the discord link within the Nav & Footer to navigate the user to the FCC discord invite page

# Overview of Change

`links.js`
- update discord href to navigate to discord invite screen

`Header.test.js`
- imported screen & render from testing-library
- wrote test to make sure we are rendering 'Discord' as the third item

`Footer.test.js`
- imported screen & render from testing-library
- wrote test to make sure we are rendering 'Discord' as the third item
