### PR TITLE
Meet-The-Admins Section

### DIFF
--- a/src/components/Members.jsx
+++ b/src/components/Members.jsx
@@ -1,8 +1,12 @@
 function Members() {
   const admin = [
-    { name: 'John', imgUrl: '/head.png' },
-    { name: 'Amy', imgUrl: '/head.png' },
-    { name: 'Kevin', imgUrl: '/head.png' },
+    { name: 'John Riley', title: 'Admin & Coding Mentor', imgUrl: 'https://avatars.githubusercontent.com/u/41979303?v=4' },
+    { name: 'Kent Utterback', title: 'Admin Emeritus & Coding Mentor', imgUrl: 'https://avatars.githubusercontent.com/u/17324971?v=4' },
+    { name: 'Amy Bedinghaus', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/28076677?v=4' },
+    { name: 'Austin Truss', title: 'Admin Emeritus', imgUrl: 'https://media.licdn.com/dms/image/C5603AQGQpynBhWiZLA/profile-displayphoto-shrink_200_200/0/1517355585710?e=1696464000&v=beta&t=DrPEzm5U1we4G7qUPoFrAA5gw_MHSN3dU8_02iWZYRA' },
+    { name: 'Kevin Bruland', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/17850505?v=4' },
+    { name: 'Sarah Lilly-Bruland', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/17872422?v=4' },
+    { name: 'Justin Woodward', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/17994108?v=4' },
   ]
   const members = [
     { name: 'John', imgUrl: '/head.png' },
@@ -21,6 +25,7 @@ function Members() {
             <div key={member.name}>
               <img className='admin' src={member.imgUrl} alt={`beautiful headshot of ${member.name}.`} />
               <h4>{member.name}</h4>
+              <h5>{member.title}</h5>
             </div>
           )}
         </div>

--- a/src/components/Members.jsx
+++ b/src/components/Members.jsx
@@ -9,12 +9,12 @@ function Members() {
     { id: 6, firstName: 'Justin', lastName: 'Woodward', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/17994108?v=4' },
   ]
   const members = [
-    { name: 'John', imgUrl: '/head.png' },
-    { name: 'Ismael', imgUrl: '/head.png' },
-    { name: 'Nirvignesh', imgUrl: '/head.png' },
-    { name: 'Tijana', imgUrl: '/head.png' },
-    { name: 'Jennifer', imgUrl: '/head.png' },
-    { name: 'Kellan', imgUrl: '/head.png' },
+    { id: 0, name: 'John', imgUrl: '/head.png' },
+    { id: 1, name: 'Ismael', imgUrl: '/head.png' },
+    { id: 2, name: 'Nirvignesh', imgUrl: '/head.png' },
+    { id: 3, name: 'Tijana', imgUrl: '/head.png' },
+    { id: 4, name: 'Jennifer', imgUrl: '/head.png' },
+    { id: 5, name: 'Kellan', imgUrl: '/head.png' },
   ]
   return (
     <div>
@@ -34,7 +34,7 @@ function Members() {
         <h3>Meet the Contributors</h3>
         <div className="row">
           {members.map((member) =>
-            <div key={member.name}>
+            <div key={member.id}>
               <img className='avatar member-avatar' src={member.imgUrl} alt={`beautiful headshot of ${member.name}.`} />
               <h4>{member.name}</h4>
             </div>

--- a/src/components/Members.jsx
+++ b/src/components/Members.jsx
@@ -1,12 +1,12 @@
 function Members() {
   const admin = [
-    { name: 'John Riley', title: 'Admin & Coding Mentor', imgUrl: 'https://avatars.githubusercontent.com/u/41979303?v=4' },
-    { name: 'Kent Utterback', title: 'Admin Emeritus & Coding Mentor', imgUrl: 'https://avatars.githubusercontent.com/u/17324971?v=4' },
-    { name: 'Amy Bedinghaus', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/28076677?v=4' },
-    { name: 'Austin Truss', title: 'Admin Emeritus', imgUrl: 'https://media.licdn.com/dms/image/C5603AQGQpynBhWiZLA/profile-displayphoto-shrink_200_200/0/1517355585710?e=1696464000&v=beta&t=DrPEzm5U1we4G7qUPoFrAA5gw_MHSN3dU8_02iWZYRA' },
-    { name: 'Kevin Bruland', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/17850505?v=4' },
-    { name: 'Sarah Lilly-Bruland', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/17872422?v=4' },
-    { name: 'Justin Woodward', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/17994108?v=4' },
+    { id: 0, firstName: 'John', lastName: 'Riley', title: 'Admin & Coding Mentor', imgUrl: 'https://avatars.githubusercontent.com/u/41979303?v=4' },
+    { id: 1, firstName: 'Kent', lastName: 'Utterback', title: 'Admin Emeritus & Coding Mentor', imgUrl: 'https://avatars.githubusercontent.com/u/17324971?v=4' },
+    { id: 2, firstName: 'Amy', lastName: 'Bedinghaus', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/28076677?v=4' },
+    { id: 3, firstName: 'Austin', lastName: 'Truss', title: 'Admin Emeritus', imgUrl: 'https://media.licdn.com/dms/image/C5603AQGQpynBhWiZLA/profile-displayphoto-shrink_200_200/0/1517355585710?e=1696464000&v=beta&t=DrPEzm5U1we4G7qUPoFrAA5gw_MHSN3dU8_02iWZYRA' },
+    { id: 4, firstName: 'Kevin', lastName: 'Bruland', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/17850505?v=4' },
+    { id: 5, firstName: 'Sarah', lastName: 'Lilly-Bruland', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/17872422?v=4' },
+    { id: 6, firstName: 'Justin', lastName: 'Woodward', title: 'Admin Emeritus', imgUrl: 'https://avatars.githubusercontent.com/u/17994108?v=4' },
   ]
   const members = [
     { name: 'John', imgUrl: '/head.png' },
@@ -22,20 +22,20 @@ function Members() {
         <h3>Meet the Admins</h3>
         <div className="row">
           {admin.map((member) =>
-            <div key={member.name}>
-              <img className='admin' src={member.imgUrl} alt={`beautiful headshot of ${member.name}.`} />
-              <h4>{member.name}</h4>
+            <div key={member.id}>
+              <h4>{member.firstName}<br/> {member.lastName}</h4>
+              <img className='avatar admin-avatar' src={member.imgUrl} alt={`beautiful headshot of ${member.firstName} ${member.lastName}.`} />
               <h5>{member.title}</h5>
             </div>
           )}
         </div>
       </div>
-      <div className="members">
+      <div className="members"> 
         <h3>Meet the Contributors</h3>
         <div className="row">
           {members.map((member) =>
             <div key={member.name}>
-              <img className='member' src={member.imgUrl} alt={`beautiful headshot of ${member.name}.`} />
+              <img className='avatar member-avatar' src={member.imgUrl} alt={`beautiful headshot of ${member.name}.`} />
               <h4>{member.name}</h4>
             </div>
           )}

--- a/src/index.css
+++ b/src/index.css
@@ -197,16 +197,18 @@ th {
   justify-content: space-evenly;
 }
 
-.admin,
-.member {
-  height: 140px;
-  width: 140px;
-  /* padding: .75em; */
+.member-avatar, 
+.admin-avatar {
   border: 1px solid #707070;
   background-color: #f5b742;
 }
 
-.member {
+.admin-avatar {
+  height: 140px;
+  width: 140px;
+}
+
+.member-avatar {
   height: 100px;
   width: 100px;
   border-radius: 50%;

--- a/src/index.css
+++ b/src/index.css
@@ -201,7 +201,7 @@ th {
 .member {
   height: 140px;
   width: 140px;
-  padding: .75em;
+  /* padding: .75em; */
   border: 1px solid #707070;
   background-color: #f5b742;
 }
@@ -210,6 +210,14 @@ th {
   height: 100px;
   width: 100px;
   border-radius: 50%;
+}
+
+.members h4 {
+  margin: 5px 0 5px 0;
+}
+
+.members h5 {
+  margin-top: 15px;
 }
 
 footer {

--- a/src/index.css
+++ b/src/index.css
@@ -197,8 +197,7 @@ th {
   justify-content: space-evenly;
 }
 
-.member-avatar, 
-.admin-avatar {
+.avatar {
   border: 1px solid #707070;
   background-color: #f5b742;
 }

--- a/src/test/__snapshots__/App.test.js.snap
+++ b/src/test/__snapshots__/App.test.js.snap
@@ -197,33 +197,94 @@ exports[`App renders 1`] = `
       >
         <div>
           <img
-            alt="beautiful headshot of John."
+            alt="beautiful headshot of John Riley."
             className="admin"
-            src="/head.png"
+            src="https://avatars.githubusercontent.com/u/41979303?v=4"
           />
           <h4>
-            John
+            John Riley
           </h4>
+          <h5>
+            Admin & Coding Mentor
+          </h5>
         </div>
         <div>
           <img
-            alt="beautiful headshot of Amy."
+            alt="beautiful headshot of Kent Utterback."
             className="admin"
-            src="/head.png"
+            src="https://avatars.githubusercontent.com/u/17324971?v=4"
           />
           <h4>
-            Amy
+            Kent Utterback
           </h4>
+          <h5>
+            Admin Emeritus & Coding Mentor
+          </h5>
         </div>
         <div>
           <img
-            alt="beautiful headshot of Kevin."
+            alt="beautiful headshot of Amy Bedinghaus."
             className="admin"
-            src="/head.png"
+            src="https://avatars.githubusercontent.com/u/28076677?v=4"
           />
           <h4>
-            Kevin
+            Amy Bedinghaus
           </h4>
+          <h5>
+            Admin Emeritus
+          </h5>
+        </div>
+        <div>
+          <img
+            alt="beautiful headshot of Austin Truss."
+            className="admin"
+            src="https://media.licdn.com/dms/image/C5603AQGQpynBhWiZLA/profile-displayphoto-shrink_200_200/0/1517355585710?e=1696464000&v=beta&t=DrPEzm5U1we4G7qUPoFrAA5gw_MHSN3dU8_02iWZYRA"
+          />
+          <h4>
+            Austin Truss
+          </h4>
+          <h5>
+            Admin Emeritus
+          </h5>
+        </div>
+        <div>
+          <img
+            alt="beautiful headshot of Kevin Bruland."
+            className="admin"
+            src="https://avatars.githubusercontent.com/u/17850505?v=4"
+          />
+          <h4>
+            Kevin Bruland
+          </h4>
+          <h5>
+            Admin Emeritus
+          </h5>
+        </div>
+        <div>
+          <img
+            alt="beautiful headshot of Sarah Lilly-Bruland."
+            className="admin"
+            src="https://avatars.githubusercontent.com/u/17872422?v=4"
+          />
+          <h4>
+            Sarah Lilly-Bruland
+          </h4>
+          <h5>
+            Admin Emeritus
+          </h5>
+        </div>
+        <div>
+          <img
+            alt="beautiful headshot of Justin Woodward."
+            className="admin"
+            src="https://avatars.githubusercontent.com/u/17994108?v=4"
+          />
+          <h4>
+            Justin Woodward
+          </h4>
+          <h5>
+            Admin Emeritus
+          </h5>
         </div>
       </div>
     </div>

--- a/src/test/__snapshots__/App.test.js.snap
+++ b/src/test/__snapshots__/App.test.js.snap
@@ -196,92 +196,113 @@ exports[`App renders 1`] = `
         className="row"
       >
         <div>
+          <h4>
+            John
+            <br />
+             
+            Riley
+          </h4>
           <img
             alt="beautiful headshot of John Riley."
-            className="admin"
+            className="avatar admin-avatar"
             src="https://avatars.githubusercontent.com/u/41979303?v=4"
           />
-          <h4>
-            John Riley
-          </h4>
           <h5>
             Admin & Coding Mentor
           </h5>
         </div>
         <div>
+          <h4>
+            Kent
+            <br />
+             
+            Utterback
+          </h4>
           <img
             alt="beautiful headshot of Kent Utterback."
-            className="admin"
+            className="avatar admin-avatar"
             src="https://avatars.githubusercontent.com/u/17324971?v=4"
           />
-          <h4>
-            Kent Utterback
-          </h4>
           <h5>
             Admin Emeritus & Coding Mentor
           </h5>
         </div>
         <div>
+          <h4>
+            Amy
+            <br />
+             
+            Bedinghaus
+          </h4>
           <img
             alt="beautiful headshot of Amy Bedinghaus."
-            className="admin"
+            className="avatar admin-avatar"
             src="https://avatars.githubusercontent.com/u/28076677?v=4"
           />
-          <h4>
-            Amy Bedinghaus
-          </h4>
           <h5>
             Admin Emeritus
           </h5>
         </div>
         <div>
+          <h4>
+            Austin
+            <br />
+             
+            Truss
+          </h4>
           <img
             alt="beautiful headshot of Austin Truss."
-            className="admin"
+            className="avatar admin-avatar"
             src="https://media.licdn.com/dms/image/C5603AQGQpynBhWiZLA/profile-displayphoto-shrink_200_200/0/1517355585710?e=1696464000&v=beta&t=DrPEzm5U1we4G7qUPoFrAA5gw_MHSN3dU8_02iWZYRA"
           />
-          <h4>
-            Austin Truss
-          </h4>
           <h5>
             Admin Emeritus
           </h5>
         </div>
         <div>
+          <h4>
+            Kevin
+            <br />
+             
+            Bruland
+          </h4>
           <img
             alt="beautiful headshot of Kevin Bruland."
-            className="admin"
+            className="avatar admin-avatar"
             src="https://avatars.githubusercontent.com/u/17850505?v=4"
           />
-          <h4>
-            Kevin Bruland
-          </h4>
           <h5>
             Admin Emeritus
           </h5>
         </div>
         <div>
+          <h4>
+            Sarah
+            <br />
+             
+            Lilly-Bruland
+          </h4>
           <img
             alt="beautiful headshot of Sarah Lilly-Bruland."
-            className="admin"
+            className="avatar admin-avatar"
             src="https://avatars.githubusercontent.com/u/17872422?v=4"
           />
-          <h4>
-            Sarah Lilly-Bruland
-          </h4>
           <h5>
             Admin Emeritus
           </h5>
         </div>
         <div>
+          <h4>
+            Justin
+            <br />
+             
+            Woodward
+          </h4>
           <img
             alt="beautiful headshot of Justin Woodward."
-            className="admin"
+            className="avatar admin-avatar"
             src="https://avatars.githubusercontent.com/u/17994108?v=4"
           />
-          <h4>
-            Justin Woodward
-          </h4>
           <h5>
             Admin Emeritus
           </h5>
@@ -300,7 +321,7 @@ exports[`App renders 1`] = `
         <div>
           <img
             alt="beautiful headshot of John."
-            className="member"
+            className="avatar member-avatar"
             src="/head.png"
           />
           <h4>
@@ -310,7 +331,7 @@ exports[`App renders 1`] = `
         <div>
           <img
             alt="beautiful headshot of Ismael."
-            className="member"
+            className="avatar member-avatar"
             src="/head.png"
           />
           <h4>
@@ -320,7 +341,7 @@ exports[`App renders 1`] = `
         <div>
           <img
             alt="beautiful headshot of Nirvignesh."
-            className="member"
+            className="avatar member-avatar"
             src="/head.png"
           />
           <h4>
@@ -330,7 +351,7 @@ exports[`App renders 1`] = `
         <div>
           <img
             alt="beautiful headshot of Tijana."
-            className="member"
+            className="avatar member-avatar"
             src="/head.png"
           />
           <h4>
@@ -340,7 +361,7 @@ exports[`App renders 1`] = `
         <div>
           <img
             alt="beautiful headshot of Jennifer."
-            className="member"
+            className="avatar member-avatar"
             src="/head.png"
           />
           <h4>
@@ -350,7 +371,7 @@ exports[`App renders 1`] = `
         <div>
           <img
             alt="beautiful headshot of Kellan."
-            className="member"
+            className="avatar member-avatar"
             src="/head.png"
           />
           <h4>

--- a/src/test/components/__snapshots__/Members.test.js.snap
+++ b/src/test/components/__snapshots__/Members.test.js.snap
@@ -13,33 +13,94 @@ exports[`Members renders 1`] = `
     >
       <div>
         <img
-          alt="beautiful headshot of John."
+          alt="beautiful headshot of John Riley."
           className="admin"
-          src="/head.png"
+          src="https://avatars.githubusercontent.com/u/41979303?v=4"
         />
         <h4>
-          John
+          John Riley
         </h4>
+        <h5>
+          Admin & Coding Mentor
+        </h5>
       </div>
       <div>
         <img
-          alt="beautiful headshot of Amy."
+          alt="beautiful headshot of Kent Utterback."
           className="admin"
-          src="/head.png"
+          src="https://avatars.githubusercontent.com/u/17324971?v=4"
         />
         <h4>
-          Amy
+          Kent Utterback
         </h4>
+        <h5>
+          Admin Emeritus & Coding Mentor
+        </h5>
       </div>
       <div>
         <img
-          alt="beautiful headshot of Kevin."
+          alt="beautiful headshot of Amy Bedinghaus."
           className="admin"
-          src="/head.png"
+          src="https://avatars.githubusercontent.com/u/28076677?v=4"
         />
         <h4>
-          Kevin
+          Amy Bedinghaus
         </h4>
+        <h5>
+          Admin Emeritus
+        </h5>
+      </div>
+      <div>
+        <img
+          alt="beautiful headshot of Austin Truss."
+          className="admin"
+          src="https://media.licdn.com/dms/image/C5603AQGQpynBhWiZLA/profile-displayphoto-shrink_200_200/0/1517355585710?e=1696464000&v=beta&t=DrPEzm5U1we4G7qUPoFrAA5gw_MHSN3dU8_02iWZYRA"
+        />
+        <h4>
+          Austin Truss
+        </h4>
+        <h5>
+          Admin Emeritus
+        </h5>
+      </div>
+      <div>
+        <img
+          alt="beautiful headshot of Kevin Bruland."
+          className="admin"
+          src="https://avatars.githubusercontent.com/u/17850505?v=4"
+        />
+        <h4>
+          Kevin Bruland
+        </h4>
+        <h5>
+          Admin Emeritus
+        </h5>
+      </div>
+      <div>
+        <img
+          alt="beautiful headshot of Sarah Lilly-Bruland."
+          className="admin"
+          src="https://avatars.githubusercontent.com/u/17872422?v=4"
+        />
+        <h4>
+          Sarah Lilly-Bruland
+        </h4>
+        <h5>
+          Admin Emeritus
+        </h5>
+      </div>
+      <div>
+        <img
+          alt="beautiful headshot of Justin Woodward."
+          className="admin"
+          src="https://avatars.githubusercontent.com/u/17994108?v=4"
+        />
+        <h4>
+          Justin Woodward
+        </h4>
+        <h5>
+          Admin Emeritus
+        </h5>
       </div>
     </div>
   </div>

--- a/src/test/components/__snapshots__/Members.test.js.snap
+++ b/src/test/components/__snapshots__/Members.test.js.snap
@@ -12,92 +12,113 @@ exports[`Members renders 1`] = `
       className="row"
     >
       <div>
+        <h4>
+          John
+          <br />
+           
+          Riley
+        </h4>
         <img
           alt="beautiful headshot of John Riley."
-          className="admin"
+          className="avatar admin-avatar"
           src="https://avatars.githubusercontent.com/u/41979303?v=4"
         />
-        <h4>
-          John Riley
-        </h4>
         <h5>
           Admin & Coding Mentor
         </h5>
       </div>
       <div>
+        <h4>
+          Kent
+          <br />
+           
+          Utterback
+        </h4>
         <img
           alt="beautiful headshot of Kent Utterback."
-          className="admin"
+          className="avatar admin-avatar"
           src="https://avatars.githubusercontent.com/u/17324971?v=4"
         />
-        <h4>
-          Kent Utterback
-        </h4>
         <h5>
           Admin Emeritus & Coding Mentor
         </h5>
       </div>
       <div>
+        <h4>
+          Amy
+          <br />
+           
+          Bedinghaus
+        </h4>
         <img
           alt="beautiful headshot of Amy Bedinghaus."
-          className="admin"
+          className="avatar admin-avatar"
           src="https://avatars.githubusercontent.com/u/28076677?v=4"
         />
-        <h4>
-          Amy Bedinghaus
-        </h4>
         <h5>
           Admin Emeritus
         </h5>
       </div>
       <div>
+        <h4>
+          Austin
+          <br />
+           
+          Truss
+        </h4>
         <img
           alt="beautiful headshot of Austin Truss."
-          className="admin"
+          className="avatar admin-avatar"
           src="https://media.licdn.com/dms/image/C5603AQGQpynBhWiZLA/profile-displayphoto-shrink_200_200/0/1517355585710?e=1696464000&v=beta&t=DrPEzm5U1we4G7qUPoFrAA5gw_MHSN3dU8_02iWZYRA"
         />
-        <h4>
-          Austin Truss
-        </h4>
         <h5>
           Admin Emeritus
         </h5>
       </div>
       <div>
+        <h4>
+          Kevin
+          <br />
+           
+          Bruland
+        </h4>
         <img
           alt="beautiful headshot of Kevin Bruland."
-          className="admin"
+          className="avatar admin-avatar"
           src="https://avatars.githubusercontent.com/u/17850505?v=4"
         />
-        <h4>
-          Kevin Bruland
-        </h4>
         <h5>
           Admin Emeritus
         </h5>
       </div>
       <div>
+        <h4>
+          Sarah
+          <br />
+           
+          Lilly-Bruland
+        </h4>
         <img
           alt="beautiful headshot of Sarah Lilly-Bruland."
-          className="admin"
+          className="avatar admin-avatar"
           src="https://avatars.githubusercontent.com/u/17872422?v=4"
         />
-        <h4>
-          Sarah Lilly-Bruland
-        </h4>
         <h5>
           Admin Emeritus
         </h5>
       </div>
       <div>
+        <h4>
+          Justin
+          <br />
+           
+          Woodward
+        </h4>
         <img
           alt="beautiful headshot of Justin Woodward."
-          className="admin"
+          className="avatar admin-avatar"
           src="https://avatars.githubusercontent.com/u/17994108?v=4"
         />
-        <h4>
-          Justin Woodward
-        </h4>
         <h5>
           Admin Emeritus
         </h5>
@@ -116,7 +137,7 @@ exports[`Members renders 1`] = `
       <div>
         <img
           alt="beautiful headshot of John."
-          className="member"
+          className="avatar member-avatar"
           src="/head.png"
         />
         <h4>
@@ -126,7 +147,7 @@ exports[`Members renders 1`] = `
       <div>
         <img
           alt="beautiful headshot of Ismael."
-          className="member"
+          className="avatar member-avatar"
           src="/head.png"
         />
         <h4>
@@ -136,7 +157,7 @@ exports[`Members renders 1`] = `
       <div>
         <img
           alt="beautiful headshot of Nirvignesh."
-          className="member"
+          className="avatar member-avatar"
           src="/head.png"
         />
         <h4>
@@ -146,7 +167,7 @@ exports[`Members renders 1`] = `
       <div>
         <img
           alt="beautiful headshot of Tijana."
-          className="member"
+          className="avatar member-avatar"
           src="/head.png"
         />
         <h4>
@@ -156,7 +177,7 @@ exports[`Members renders 1`] = `
       <div>
         <img
           alt="beautiful headshot of Jennifer."
-          className="member"
+          className="avatar member-avatar"
           src="/head.png"
         />
         <h4>
@@ -166,7 +187,7 @@ exports[`Members renders 1`] = `
       <div>
         <img
           alt="beautiful headshot of Kellan."
-          className="member"
+          className="avatar member-avatar"
           src="/head.png"
         />
         <h4>


### PR DESCRIPTION
# TL/DR
This PR updates the admin section by adding new admin photos + their titles

# Overview of Change

`Members.jsx`
- Add new members + their titles
- Add `<h5>` for newly added member titles

`index.css`
- Commented out padding .75em from `.member` class (temporary based on opinion)
- Add styling for admins name and titles (h4 & h5's)
- change `member` className to `admin/member-avatar`
- edit array so we can seperate first and last name
- add id to admin so we always have unique keys


With Padding:
![admins-padding](https://github.com/FCCColumbus/cbus-web/assets/77947488/bd870138-3657-4d5c-b39d-2594fae17d1d)


Without Padding:
![admins-no-padding](https://github.com/FCCColumbus/cbus-web/assets/77947488/cdd913e3-acb0-4ae3-932f-7c74340204ba)