### PR TITLE
Add-Code-Coverage-Report

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   "jest": {
     "collectCoverageFrom": [
         "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}",
-        "!src/reportWebVitals.js"
+        "!src/reportWebVitals.js",
+        "!src/index.js"
       ]  
     }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false --coverage",
     "eject": "react-scripts eject",
     "lint": "eslint . --ext js,jsx,ts,tsx --fix"
   },
@@ -66,5 +66,11 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "jest": {
+    "collectCoverageFrom": [
+        "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}",
+        "!src/reportWebVitals.js"
+      ]  
+    }
 }


### PR DESCRIPTION
# TL/DR
This PR updates the test script, allowing a coverage report to be generated upon running 
`npm run test`

# Overview of Change

`package.json`
- add coverage flag & turned off watchAll to our test script
- add jest configuration to ignore `reportWebVitals.js` when running tests
